### PR TITLE
Fix TwitterApiExchange namespace since the package is different.

### DIFF
--- a/Services/Manager/TweetManager.php
+++ b/Services/Manager/TweetManager.php
@@ -4,7 +4,7 @@ namespace Headoo\MediaSocialApiBundle\Services\Manager;
 
 use Doctrine\ORM\EntityManager;
 use Headoo\MediaSocialApiBundle\Entity\Tweet;
-use JoseiOgr\TwitterAPIPHP\Connector\TwitterAPIExchange;
+use TwitterAPIExchange;
 
 class TweetManager extends GenericManager
 {


### PR DESCRIPTION
The current namespace for TwitterApiExchange is incorrect, this PR fixes it.